### PR TITLE
Add name argument to service start script

### DIFF
--- a/scripts/Stackdriver/install_stackdriver.ps1
+++ b/scripts/Stackdriver/install_stackdriver.ps1
@@ -12,7 +12,7 @@ if (Test-Path C:\dev\data\$($loggingagent)) {
     }
     elseif (Get-Service "StackdriverLogging" | Where-Object {$_.Status -eq "Stopped"}) {
         Write-Host "Starting service"
-        Start-Service "StackdriverLogging"
+        Start-Service -Name "StackdriverLogging"
     }
     else {
         Write-Host "Error, service not found..."
@@ -36,7 +36,7 @@ if (Test-Path C:\dev\data\$monitoringagent) {
     }
     elseif (Get-Service "StackdriverMonitoring" | Where-Object {$_.Status -eq "Stopped"}) {
         Write-Host "Starting service"
-        Start-Service "StackdriverMonitoring"
+        Start-Service -Name "StackdriverMonitoring"
     }
     else {
         Write-Host "Error, service not found..."


### PR DESCRIPTION
I believe the issue with this bit of the script is that I didn't pass the -Name argument which appears to be required (unlike the Get-Service which assumes it as default), docs here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-service?view=powershell-7.1