### PR TITLE
Change bucket reference in URL rewrite script

### DIFF
--- a/pipelines/configure_blaise.yml
+++ b/pipelines/configure_blaise.yml
@@ -79,8 +79,6 @@ stages:
               steps:
               - checkout: self
               - template: /templates/blaise_management_steps.yml
-                parameters:
-                  GCP_Bucket: $($env:ENV_BLAISE_GCP_BUCKET)
 
       - deployment: RegisterDataEntryNodes
         condition: eq(variables.ENV_MULTI_NODE, true)

--- a/scripts/Blaise/blaise_url_rewrite.ps1
+++ b/scripts/Blaise/blaise_url_rewrite.ps1
@@ -6,7 +6,7 @@ function CheckIfURLRewriteMsiExists {
     else
     {
       Write-Host "Downloading rewrite_url.msi"
-      gsutil cp gs://$GCP_BUCKET/rewrite_url.msi "C:\dev\data\rewrite_url.msi"
+      gsutil cp gs://$env:ENV_BLAISE_GCP_BUCKET/rewrite_url.msi "C:\dev\data\rewrite_url.msi"
     }    
 }
 


### PR DESCRIPTION
This fixes an error I just spotted when bootstraping a new sandbox.
What I observed is the error "Command Exception: "cp" command does not support provider-only URLs" 
This meant that URL rewrite task within this deployment didn't complete correctly as it didn't download the exe.
I have just applied this branch against my sandbox and it stepped through the problem some step. 