### PR TITLE
Merging changes from main to 516

### DIFF
--- a/pipelines/configure_blaise.yml
+++ b/pipelines/configure_blaise.yml
@@ -160,6 +160,9 @@ stages:
           runOnce:
             deploy:
               steps:
+                - template: /templates/download_gcloud_sdk.yml
+                  parameters:
+                    TAG: mgmt
                 - template: /templates/download_dotnet_installation_files.yml
                 - template: /templates/install_dotnet_sdk.yml
                 - template: /templates/install_dotnet_windows_hosting_bundle.yml
@@ -175,6 +178,9 @@ stages:
           runOnce:
             deploy:
               steps:
+                - template: /templates/download_gcloud_sdk.yml
+                  parameters:
+                    TAG: mgmt
                 - template: /templates/download_dotnet_installation_files.yml
                 - template: /templates/install_dotnet_sdk.yml
                 - template: /templates/install_dotnet_windows_hosting_bundle.yml


### PR DESCRIPTION
Leaving til after cn6 has finished testing, but this step will download latest gcloud sdk onto data entry machines which is needed to use WIF to download .net installers